### PR TITLE
Add yarn.lock cache for faster CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,20 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:8.2.1
+      - image: circleci/node:8.2.1
     working_directory: ~/promptpay-qr
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - yarn-v1-{{ checksum "yarn.lock" }}
+            - yarn-v1-
       - run: |
           yarn
+      - save_cache:
+          key: yarn-v1-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn/v1
       - run: |
           yarn test
       - run: |


### PR DESCRIPTION
👷 I've changed docker image to CircleCI node with yarn.lock caching help CI build faster